### PR TITLE
Implement Option.flatten and Option.flatten_one methods.

### DIFF
--- a/rusty_results/prelude.py
+++ b/rusty_results/prelude.py
@@ -218,7 +218,7 @@ class OptionProtocol(Generic[T]):
         ...  # pragma: no cover
 
     @abstractmethod
-    def flatten_one(self) -> Union[T, "Option[T]"]:
+    def flatten_one(self) -> "Option[T]":
         """
         Removes one level from a nested `Option` structure.
         E.g.:
@@ -229,7 +229,7 @@ class OptionProtocol(Generic[T]):
         ...  # pragma: no cover
 
     @abstractmethod
-    def flatten(self):
+    def flatten(self) -> "Option[T]":
         """
         Removes all levels of nesting from a nested `Option` structure.
         E.g.:
@@ -391,18 +391,18 @@ class Some(OptionProtocol[T]):
     def unwrap_empty(self):
         self.expect_empty("")
 
-    def flatten_one(self) -> Union[T, "Option[T]"]:
+    def flatten_one(self) -> "Option[T]":
         inner: T = self.unwrap()
         if isinstance(inner, OptionProtocol):
             return inner  # type: ignore[return-value]
         return self
 
-    def flatten(self) -> OptionProtocol[U]:
-        this: Union[T, "Option[T]"] = self
-        inner: Union[T, "Option[T]"] = self.flatten_one()
-        while inner != this:
-            this, inner = (inner, inner.flatten_one())  # type: ignore[union-attr]
-        return this  # type: ignore[return-value]
+    def flatten(self) -> "Option[T]":
+        this: Option[T] = self
+        inner: Option[T] = self.flatten_one()
+        while isinstance(inner, OptionProtocol):
+            this, inner = (inner, inner.flatten_one())
+        return this
 
     def __bool__(self) -> bool:
         return True
@@ -479,7 +479,7 @@ class Empty(OptionProtocol):
     def unwrap_empty(self):
         ...
 
-    def flatten_one(self) -> Union[T, "Option[T]"]:
+    def flatten_one(self) -> "Option[T]":
         return self
 
     def flatten(self) -> "Option[T]":

--- a/rusty_results/prelude.py
+++ b/rusty_results/prelude.py
@@ -400,7 +400,7 @@ class Some(OptionProtocol[T]):
     def flatten(self) -> "Option[T]":
         this: Option[T] = self
         inner: Option[T] = self.flatten_one()
-        while isinstance(inner, OptionProtocol):
+        while inner is not this:
             this, inner = (inner, inner.flatten_one())
         return this
 

--- a/rusty_results/prelude.py
+++ b/rusty_results/prelude.py
@@ -401,7 +401,7 @@ class Some(OptionProtocol[T]):
         this: Union[T, "Option[T]"] = self
         inner: Union[T, "Option[T]"] = self.flatten_one()
         while inner != this:
-            this, inner = (inner, this.flatten_one())  # type: ignore[union-attr]
+            this, inner = (inner, inner.flatten_one())  # type: ignore[union-attr]
         return this  # type: ignore[return-value]
 
     def __bool__(self) -> bool:

--- a/rusty_results/prelude.py
+++ b/rusty_results/prelude.py
@@ -218,7 +218,7 @@ class OptionProtocol(Generic[T]):
         ...  # pragma: no cover
 
     @abstractmethod
-    def flatten_one(self) -> "Option[T]":
+    def flatten_one(self) -> Union[T, "Option[T]"]:
         """
         Removes one level from a nested `Option` structure.
         E.g.:
@@ -391,19 +391,18 @@ class Some(OptionProtocol[T]):
     def unwrap_empty(self):
         self.expect_empty("")
 
-    def flatten_one(self) -> "Option[T]":
+    def flatten_one(self) -> Union[T, "Option[T]"]:
         inner: T = self.unwrap()
         if isinstance(inner, OptionProtocol):
-            return inner
+            return inner  # type: ignore[return-value]
         return self
 
-    def flatten(self) -> "Option[T]":
-        this: Some = self
-        inner: Option[T] = this.flatten_one()
+    def flatten(self) -> OptionProtocol[U]:
+        this: Union[T, "Option[T]"] = self
+        inner: Union[T, "Option[T]"] = self.flatten_one()
         while inner != this:
-            this = inner
-            inner = this.flatten_one()
-        return this
+            this, inner = (inner, this.flatten_one())  # type: ignore[union-attr]
+        return this  # type: ignore[return-value]
 
     def __bool__(self) -> bool:
         return True
@@ -480,7 +479,7 @@ class Empty(OptionProtocol):
     def unwrap_empty(self):
         ...
 
-    def flatten_one(self) -> "Option[T]":
+    def flatten_one(self) -> Union[T, "Option[T]"]:
         return self
 
     def flatten(self) -> "Option[T]":

--- a/rusty_results/tests/option/test_option_empty.py
+++ b/rusty_results/tests/option/test_option_empty.py
@@ -90,3 +90,13 @@ def test_empty_expect_none():
 
 def test_empty_unwrap_empty():
     Empty().unwrap_empty()
+
+
+def test_flatten():
+    this: Empty = Empty()
+    assert this.flatten_one() == this
+
+
+def test_flatten_all():
+    this: Empty = Empty()
+    assert this.flatten() == this

--- a/rusty_results/tests/option/test_option_some.py
+++ b/rusty_results/tests/option/test_option_some.py
@@ -128,3 +128,31 @@ def test_some_unwrap_empty():
     some, value = create_some()
     with pytest.raises(Exception):
         some.unwrap_empty()
+
+
+@pytest.mark.parametrize(
+    "option, expected_flatten",
+    [
+        (Some(1), Some(1)),
+        (Some(Some(2)), Some(2)),
+        (Some(Some(Some(3))), Some(Some(3))),
+        (Some(Empty()), Empty()),
+        (Some(Some(Some(Some(Some(Some(Empty())))))), Some(Some(Some(Some(Some(Empty())))))),
+    ]
+)
+def test_flatten_one(option: Option, expected_flatten: Option):
+    assert option.flatten_one() == expected_flatten
+
+
+@pytest.mark.parametrize(
+    "option, expected_flatten",
+    [
+        (Some(1), Some(1)),
+        (Some(Some(2)), Some(2)),
+        (Some(Some(Some(3))), Some(3)),
+        (Some(Empty()), Empty()),
+        (Some(Some(Some(Some(Some(Some(Empty())))))), Empty()),
+    ]
+)
+def test_flatten(option: Option, expected_flatten: Option):
+    assert option.flatten() == expected_flatten


### PR DESCRIPTION
# Summary of the Pull Request
Implement two methods for the `OptionProtocol` classes: Some and Empty.
#### Methods
* `flatten_one`: Removes one nesting level from a nested `Option` structure.
* `flatten`: Removes all nesting levels (leaving the last) from a nested `Option` structure.