### PR TITLE
Exclude tests from packaging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 **/.idea/
+dist/
+*.egg-info/
+__pycache__/

--- a/setup.py
+++ b/setup.py
@@ -11,21 +11,15 @@ setuptools.setup(
     description="Rust inspired Result and Option types",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="",
+    url="https://github.com/danielSanchezQ/rusty_results",
     package_data={".": ["py.typed"]},
-    packages=setuptools.find_packages(
-        ".",
-        exclude=[
-            "tests*",
-            "examples*"
-        ]
-    ),
+    packages=setuptools.find_packages(exclude=("*tests*",)),
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
     extras_require={
-        'pydantic': ["pydantic"]
+        "pydantic": ["pydantic"]
     },
     python_requires='>=3.7'
 )


### PR DESCRIPTION
# Summary
1. Don't package `tests` package and sub-packages.
2. Remove the `example` package exclusion, as that's not packaged in the first place.
3. Extra: Point the URL parameter to this repo's URL.